### PR TITLE
Change props type from array to object

### DIFF
--- a/src/components/MetadataSidebar.vue
+++ b/src/components/MetadataSidebar.vue
@@ -115,39 +115,39 @@ export default defineComponent({
       default: false
     },
     patientInformation: {
-      type: Array,
+      type: Object,
       required: true
     },
     studyInformation: {
-      type: Array,
+      type: Object,
       required: true
     },
     seriesInformation: {
-      type: Array,
+      type: Object,
       required: true
     },
     instanceInformation: {
-      type: Array,
+      type: Object,
       required: true
     },
     imageInformation: {
-      type: Array,
+      type: Object,
       required: true
     },
     equipmentInformation: {
-      type: Array,
+      type: Object,
       required: true
     },
     scanningInformation: {
-      type: Array,
+      type: Object,
       required: true
     },
     uidsInformation: {
-      type: Array,
+      type: Object,
       required: true
     },
     otherInformation: {
-      type: Array,
+      type: Object,
       required: true
     }
   },

--- a/src/components/MetadataSidebarTableRow.vue
+++ b/src/components/MetadataSidebarTableRow.vue
@@ -25,7 +25,7 @@ export default defineComponent({
       required: true
     },
     metadataSectionData: {
-      type: Array,
+      type: Object,
       required: true
     }, 
     isFirstSection: {


### PR DESCRIPTION
## Description
Changed the type of props to `Object`. 

## Motivation and Context
This pr fixes the warning(Vue warn) related to prop type check while running unit tests 

## Screenshots (if appropriate):
![Screenshot from 2024-02-08 12-42-02](https://github.com/owncloud/web-app-dicom-viewer/assets/53458341/4491f5f4-b12d-4c84-9d7c-aaf8a9049ce3)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added