### PR TITLE
make UI text translatable

### DIFF
--- a/src/components/MetadataSidebar.vue
+++ b/src/components/MetadataSidebar.vue
@@ -13,9 +13,7 @@
       >
         <oc-icon name="arrow-left-s" fill-type="line" />
       </oc-button>
-
-      <h2 class="header__title oc-my-rm">DICOM metadata</h2>
-
+      <h2 class="header__title oc-my-rm">{{ dicomMetadataSidebarTitle }}</h2>
       <oc-button
         v-oc-tooltip="hideMetadataDescription"
         class="header__close"
@@ -156,6 +154,7 @@ export default defineComponent({
     const { $gettext } = useGettext()
 
     return {
+      dicomMetadataSidebarTitle: $gettext('DICOM metadata'),
       hideMetadataDescription: $gettext('Hide DICOM metadata'),
       backToMainDescription: $gettext('Back to DICOM viewer'), 
     }

--- a/src/components/VipMetadataOverlay.vue
+++ b/src/components/VipMetadataOverlay.vue
@@ -1,26 +1,19 @@
 <template>
-    <div
-          id="dicom-viewer-vip-metadata"
-          class="oc-position-absolute"
-        >
-          <div class="oc-pr-s oc-font-semibold">
-            <span>{{ patientName || 'patient name not defined' }}</span>
-            <span>
-              (*{{ patientBirthdate || 'birthdate not defined'
-              }})</span
-            >
-          </div>
-          <div class="oc-pr-s oc-font-semibold">
-            <span>{{ institutionName || 'institution name not defined' }}</span
-            >,
-            <span> {{ instanceCreationDateTime || 'instance creation date and time not defined'
-            }}</span>
-          </div>
-        </div>
+  <div id="dicom-viewer-vip-metadata" class="oc-position-absolute" >
+    <div class="oc-pr-s oc-font-semibold">
+      <span>{{ patientName || patientNameNotDefined }}, </span>
+      <span>*{{ patientBirthdate || birthdateNotDefined }}</span>
+    </div>
+    <div class="oc-pr-s oc-font-semibold">
+      <span>{{ institutionName || institutionNameNotDefined }}</span>,
+      <span> {{ instanceCreationDateTime || instanceCreationDateAndTimeNotDefined }}</span>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { useGettext } from 'vue3-gettext'
 
 export default defineComponent({
   name: 'VipMetadataOverlay',
@@ -40,6 +33,16 @@ export default defineComponent({
     instanceCreationDateTime: {
       type: String,
       required: false
+    }
+  },
+  setup(props) {
+    const { $gettext } = useGettext()
+
+    return {
+      patientNameNotDefined: $gettext('patient name not defined'),
+      birthdateNotDefined: $gettext('birthdate not defined'),
+      institutionNameNotDefined: $gettext('institution name not defined'),
+      instanceCreationDateAndTimeNotDefined: $gettext('instance creation date and time not defined'),
     }
   }
 })


### PR DESCRIPTION
## Description
using `$gettext` for UI text elements in order to make all text elements translatable 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
usability / UX improvement, no corresponding open issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
give possibility to translate UI into other languages. this increases usability & user experience for users that are not native english (once translations have been added...)

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added