### PR TITLE
testcase for MetadataSidebarTableRow

### DIFF
--- a/src/components/MetadataSidebarTableRow.vue
+++ b/src/components/MetadataSidebarTableRow.vue
@@ -35,16 +35,13 @@ export default defineComponent({
   },
   methods: {
     formatLabel(label: string) {
-      // formatting camelcase labels into easily readible labels by adding a gap befor each upper case letter
+      // formatting camelcase labels into easily readable labels by adding a gap before each upper case letter
       // there is no space added if there are multiple upper case letters in a row (e.g. ID)
       // in cases where such an abbreviation is followed by another word and underline should be added in the variable name, e.g. "SOP_InstanceUID" becomes "SOP Instance UID"
 
       const result = label.replace(/([A-Z]+)/g, ' $1').replace('_', '')
 
-      // optionally make first letter of each word lower?
-      // return upperFirst(result.toLowerCase())
-
-      return upperFirst(result)
+      return upperFirst(result.trim())
     }
   }
 })

--- a/tests/unit/app.spec.ts
+++ b/tests/unit/app.spec.ts
@@ -5,17 +5,7 @@ import App from '../../src/App.vue'
 
 
 // defining data
-const dicomTestFilePath = './testfiles/MRBRAIN.dcm' 
-
-const dicomFiles = [
-  {
-    id: '1',
-    name: 'MRBRAIN.dcm',
-    mimeType: 'application/dicom',
-    path: 'personal/admin/MRBRAIN.dcm'
-  }
-] // so far not used in any test case
-
+const dicomTestFilePath = './testfiles/MRBRAIN.dcm'
 
 // test cases
 describe('Dicom viewer app', () => {
@@ -23,7 +13,7 @@ describe('Dicom viewer app', () => {
   // pending tests syntax example
   describe.todo('example for unimplemented test suite')
 
-  describe('example for an group of tests where implementaito is still pending', () => {
+  describe('example for an group of tests where implementation is still pending', () => {
     it.todo('example for unimplemented test 1')
     it.todo('example for unimplemented test 2')
   })
@@ -192,23 +182,7 @@ describe('dicom viewer app', () => {
   })
 })
 
-// test formatLabel() method
-describe('dicom viewer app', () => {
-  describe('Method "formatLabel()"', () => {
-    it('should format a metadata variable name into a nicely readible label', () => {
-      const label = 'patientName'
-      const formatedLabel = 'Patient Name'
-      expect(App.methods.formatLabel(label)).toEqual(formatedLabel)
-      // TODO: call the function through the wrapper? wrapper.vm.formatLabel(label)
-    })
-    it('should format a metadata variable name with underlines and abbreviations into a nicely readible label', () => {
-      const label = 'SOP_InstanceUID'
-      const formatedLabel = 'SOP Instance UID'
-      expect(App.methods.formatLabel(label)).toEqual(formatedLabel)
-      // TODO: call the function through the wrapper? wrapper.vm.formatLabel(label)
-    })
-  })
-})
+
 
 function getWrapper(props = {}) {
   return {

--- a/tests/unit/components/MetadataSidebarTableRow.spec.ts
+++ b/tests/unit/components/MetadataSidebarTableRow.spec.ts
@@ -69,9 +69,7 @@ describe('MetadataSidebarTableRow component', () => {
     it('should format a metadata variable name with underlines and abbreviations into a nicely readible label', () => {
       const label = 'SOP_InstanceUID'
       const formattedLabel = 'SOP Instance UID'
-
       const { wrapper } = getWrapper()
-      console.log('formatted label: ' + wrapper.vm.formatLabel(label))
       expect(wrapper.vm.formatLabel(label)).toEqual(formattedLabel)
     })
   })

--- a/tests/unit/components/MetadataSidebarTableRow.spec.ts
+++ b/tests/unit/components/MetadataSidebarTableRow.spec.ts
@@ -59,6 +59,22 @@ describe('MetadataSidebarTableRow component', () => {
       expect(wrapper.html()).not.toContain('dicom-metadata-first-section')
     })
   })
+  describe('formatting labels', () => {
+    it('should format a metadata variable name into a nicely readible label', () => {
+      const label = 'patientName'
+      const formattedLabel = 'Patient Name'
+      const { wrapper } = getWrapper()
+      expect(wrapper.vm.formatLabel(label)).toEqual(formattedLabel)
+    })
+    it('should format a metadata variable name with underlines and abbreviations into a nicely readible label', () => {
+      const label = 'SOP_InstanceUID'
+      const formattedLabel = 'SOP Instance UID'
+
+      const { wrapper } = getWrapper()
+      console.log('formatted label: ' + wrapper.vm.formatLabel(label))
+      expect(wrapper.vm.formatLabel(label)).toEqual(formattedLabel)
+    })
+  })
 })
 
 function getWrapper(props = {}) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fixing minor bug with formatLabel() function regarding handling of strings starting with empty character and moving the corresponding test case into MetadataSidebarTableRow.spec.ts


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- partially fixes [24](https://github.com/owncloud/web-app-dicom-viewer/issues/24)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
moving the test case for formatLabel() function into the correct test file (hadn't been moved after refactoring of that component)

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added