### PR TITLE
add config for vitest coverage report table

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: 'lcov'
+      reporter: ['lcov', 'text']
     }
     /*
     // solution suggested by CLI, might be related to this issue: https://github.com/koebel/web/pull/2/files


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Previously, in a [PR-13](https://github.com/owncloud/web-app-dicom-viewer/commit/0bc150a083d8cf1d887e35e4288596a89776d3c8#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92), the file `vitest.config.ts` was added, which only stored the coverage report in the LCOV format. In this pull request, Jest coverage reporting is also enabled, presenting the coverage report in the form of text, where the table will display in the command prompt.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- The coverage table not display when running cmd `pnpm run coverage`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->
After configuration the table will appear
![image](https://github.com/owncloud/web-app-dicom-viewer/assets/61624650/288b31ab-88a2-4bcb-9ae6-0c5d1575649c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added