### PR TITLE
colour of show metadata icon

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,6 @@
           "
           class="preview-controls-show-metadata oc-m-s oc-p-xs"
           appearance="raw"
-          variation="brand"
           :aria-label="
             isShowMetadataActivated ? imageHideMetadataDescription : imageShowMetadataDescription
           "


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
in dark mode the show metadata sidebar icon (in the top left of screenshots below) was not visible, removed the 'brand' styling variant 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
improve usability & accessibility

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->
before
![Screen Shot 2024-03-06 at 15 16 50](https://github.com/owncloud/web-app-dicom-viewer/assets/8348693/3513bc24-7635-47c3-9375-31245669222b)

after
![Screen Shot 2024-03-06 at 15 19 09](https://github.com/owncloud/web-app-dicom-viewer/assets/8348693/2e065819-917b-4083-9134-7916fa44375d)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added