### PR TITLE
Add unit test for fetchVipMetadataInformation method

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -202,19 +202,16 @@ export default defineComponent({
     }
   },
   // vue js lifecylce functions
-  async created() {
-    // get resource, ensure resource url is not empty!
-    if (this.url != null && this.url != undefined && this.url != '') {
-      this.dicomUrl = await this.addWadouriPrefix(this.url)
-    }
 
-    // get vip metadata
-    await this.fetchVipMetadataInformation(await this.addWadouriPrefix(this.url))
-
-    // prefetch all other metadata (in separate function for performance reasons)
-    await this.fetchMetadataInformation(await this.addWadouriPrefix(this.url))
-  },
   async mounted() {
+    if (this.url) {
+      this.dicomUrl = await this.addWadouriPrefix(this.url)
+      // get vip metadata
+      await this.fetchVipMetadataInformation(this.dicomUrl)
+
+      // prefetch all other metadata (in separate function for performance reasons)
+      await this.fetchMetadataInformation(this.dicomUrl)
+    }
     // check if cornerstone core is initialized
     if (!cornerstone.isCornerstoneInitialized()) {
       await this.initCornerstoneCore()
@@ -248,11 +245,9 @@ export default defineComponent({
     this.viewport = <Types.IStackViewport>this.renderingEngine.getViewport(viewportId)
 
     // add resource to stack, ensure resource url is not empty!
-    if (this.url != null && this.url != undefined && this.url != '') {
-      let dicomResourceUrl = await this.addWadouriPrefix(this.url)
-
+    if (this.dicomUrl) {
       // define a stack containing a single image
-      const dicomStack = [dicomResourceUrl]
+      const dicomStack = [this.dicomUrl]
 
       // set stack on the viewport (currently only one image in the stack, therefore no frame # required)
       await this.viewport.setStack(dicomStack)
@@ -262,7 +257,7 @@ export default defineComponent({
       this.setViewportCameraParallelScaleFactor()
 
       // getting image metadata from viewport
-      this.getImageMetadataFromViewport(dicomResourceUrl)
+      this.getImageMetadataFromViewport(this.dicomUrl)
     }
   },
   updated() {
@@ -277,6 +272,7 @@ export default defineComponent({
     this.isImageMetadataExtractedFromViewport = false
     this.isDicomImageDataFetched = false
   },
+
   methods: {
     async initCornerstoneCore() {
       try {
@@ -291,10 +287,8 @@ export default defineComponent({
     async fetchVipMetadataInformation(imageId) {
       if (!this.isDicomImageDataFetched) {
         this.dicomImageData = await fetchDicomImageData(imageId)
-        if (!this.isDicomImageDataFetched) {
-          if (this.dicomImageData != null) {
-            this.isDicomImageDataFetched = true
-          }
+        if (this.dicomImageData != null) {
+          this.isDicomImageDataFetched = true
         }
       }
 

--- a/src/helper/extractMetadata.ts
+++ b/src/helper/extractMetadata.ts
@@ -31,11 +31,7 @@ export const addSopTagChecker = (tag: string): boolean => {
   return tag.endsWith('_addSOPuids') ? true : false
 }
 
-export const extractDicomMetadata = async (
-  imageData: object,
-  tags: string[],
-  language: string = 'en'
-) => {
+export const extractDicomMetadata = async (imageData: object, tags: string[], language = 'en') => {
   const extractedData: { label: string; value: string }[] = []
 
   // extracting data

--- a/tests/e2e/hooks.ts
+++ b/tests/e2e/hooks.ts
@@ -41,7 +41,9 @@ After(async function (): Promise<void> {
 
 const sendRequest = function ({ method, path }): Promise<any> {
   const headers = {
-    Authorization: `Basic ${Buffer.from(`${config.adminUser}:${config.adminPassword}`).toString('base64')}`
+    Authorization: `Basic ${Buffer.from(`${config.adminUser}:${config.adminPassword}`).toString(
+      'base64'
+    )}`
   }
   return axios({
     method,


### PR DESCRIPTION
## Description
Added unit test for fetching overlay metadata during execution of created hook.
Methods invoked during created hook are spied on to validate whether or not those methods has been called


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added