### PR TITLE
Move e2e assertion to context file

### DIFF
--- a/tests/e2e/features/dicomViewer.feature
+++ b/tests/e2e/features/dicomViewer.feature
@@ -8,9 +8,9 @@ Feature: Preview dicom image
     Given the dicom file "MRBRAIN.dcm" has been uploaded
     And the user "Admin" has logged in
     When the user previews the dicom file "MRBRAIN.dcm"
-    And the user checks VIP metadata for dicom file
-    Then the user should see patient name "MR/BRAIN/GRASE/1024" in VIP metadata
+    Then the user should see the dicom file "MRBRAIN.dcm"
+    And the user should see patient name "MR/BRAIN/GRASE/1024" in the VIP metadata section
     When the user checks the extended metadata for dicom file
-    Then the user should see patient name "MR/BRAIN/GRASE/1024" in metadata sidebar
-    And the user closes the DICOM file preview
-    And the user logs out
+    Then the user should see patient name "MR/BRAIN/GRASE/1024" in the metadata sidebar
+    When the user closes the metadata sidebar
+    Then the metadata sidebar should not be displayed

--- a/tests/e2e/hooks.ts
+++ b/tests/e2e/hooks.ts
@@ -1,22 +1,14 @@
 import { Before, BeforeAll, After, AfterAll, setDefaultTimeout } from '@cucumber/cucumber'
-import { Browser, chromium, Page } from '@playwright/test'
+import { chromium } from '@playwright/test'
 import { xml2js } from 'xml-js'
 import { _ } from 'lodash'
 import { config } from './config.js'
 import { sendRequest } from './api/APIHelper'
 
-export const state: {
-  browser: Browser
-  page: Page
-} = {
-  browser: undefined,
-  page: undefined
-}
-
 setDefaultTimeout(config.timeout * 1000)
 
 BeforeAll(async function (): Promise<void> {
-  state.browser = await chromium.launch({
+  global.browser = await chromium.launch({
     slowMo: config.slowMo,
     headless: config.headless,
     channel: 'chrome'
@@ -24,18 +16,18 @@ BeforeAll(async function (): Promise<void> {
 })
 
 Before(async function (): Promise<void> {
-  const context = await state.browser.newContext({ ignoreHTTPSErrors: true })
-  state.page = await context.newPage()
+  global.context = await global.browser.newContext({ ignoreHTTPSErrors: true })
+  global.page = await global.context.newPage()
 })
 
 AfterAll(async function (): Promise<void> {
-  await state.browser.close()
+  await global.browser.close()
 })
 
 After(async function (): Promise<void> {
   await deleteDicomFile()
   await emptyTrashbin()
-  await state.page.close()
+  await global.page.close()
 })
 
 const deleteDicomFile = async function (): Promise<void> {


### PR DESCRIPTION
## Description
Moved the assertion statements from Page object to context file.


## Related Issue
- Fixes https://github.com/owncloud/web-app-dicom-viewer/issues/41

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added