### PR TITLE
adding error checking for hooks & API helper functions

### DIFF
--- a/tests/e2e/api/APIHelper.ts
+++ b/tests/e2e/api/APIHelper.ts
@@ -3,17 +3,20 @@ import axios from 'axios'
 import join from 'join-path'
 
 export const sendRequest = function ({ method, path, header = null, data = null }): Promise<any> {
-  const headers = {
-    ...header,
-    Authorization: `Basic ${Buffer.from(`${config.adminUser}:${config.adminPassword}`).toString(
-      'base64'
-    )}`
+  try {
+    const headers = {
+      ...header,
+      Authorization: `Basic ${Buffer.from(`${config.adminUser}:${config.adminPassword}`).toString(
+        'base64'
+      )}`
+    }
+    return axios({
+      method,
+      url: join(config.baseUrlOcis, path),
+      headers,
+      data
+    })
+  } catch (error) {
+    throw new Error(error.message)
   }
-
-  return axios({
-    method,
-    url: join(config.baseUrlOcis, path),
-    headers,
-    data
-  })
 }

--- a/tests/e2e/hooks.ts
+++ b/tests/e2e/hooks.ts
@@ -30,14 +30,20 @@ After(async function (): Promise<void> {
   await global.page.close()
 })
 
-const deleteDicomFile = async function (): Promise<void> {
+const deleteDicomFile = async function (): Promise<any> {
   const response = await sendRequest({ method: 'PROPFIND', path: 'remote.php/dav/files/admin' })
   const xmlResponse = response.data
   const result = xml2js(xmlResponse, { compact: true })
   const resp = _.get(result, 'd:multistatus.d:response')
   const href = _.get(resp[1], 'd:href._text')
-
-  await sendRequest({ method: 'DELETE', path: href })
+  const response2 = await sendRequest({
+    method: 'DELETE',
+    path: href
+  })
+  if (response2.status !== 204) {
+    throw new Error(`Failed to delete file`)
+  }
+  return response2.status
 }
 
 const emptyTrashbin = async function (): Promise<any> {

--- a/tests/e2e/hooks.ts
+++ b/tests/e2e/hooks.ts
@@ -40,6 +40,13 @@ const deleteDicomFile = async function (): Promise<void> {
   await sendRequest({ method: 'DELETE', path: href })
 }
 
-const emptyTrashbin = async function (): Promise<void> {
-  await sendRequest({ method: 'DELETE', path: 'remote.php/dav/trash-bin/admin' })
+const emptyTrashbin = async function (): Promise<any> {
+  const response = await sendRequest({
+    method: 'DELETE',
+    path: 'remote.php/dav/trash-bin/admin'
+  })
+  if (response.status !== 204) {
+    throw new Error(`Failed to empty trashbin`)
+  }
+  return response.status
 }

--- a/tests/e2e/hooks.ts
+++ b/tests/e2e/hooks.ts
@@ -30,7 +30,7 @@ After(async function (): Promise<void> {
   await global.page.close()
 })
 
-const deleteDicomFile = async function (): Promise<any> {
+const deleteDicomFile = async function (): Promise<void> {
   const response = await sendRequest({ method: 'PROPFIND', path: 'remote.php/dav/files/admin' })
   const xmlResponse = response.data
   const result = xml2js(xmlResponse, { compact: true })
@@ -41,12 +41,11 @@ const deleteDicomFile = async function (): Promise<any> {
     path: href
   })
   if (response2.status !== 204) {
-    throw new Error(`Failed to delete file`)
+    throw new Error(`Failed to delete dicom file`)
   }
-  return response2.status
 }
 
-const emptyTrashbin = async function (): Promise<any> {
+const emptyTrashbin = async function (): Promise<void> {
   const response = await sendRequest({
     method: 'DELETE',
     path: 'remote.php/dav/trash-bin/admin'
@@ -54,5 +53,4 @@ const emptyTrashbin = async function (): Promise<any> {
   if (response.status !== 204) {
     throw new Error(`Failed to empty trashbin`)
   }
-  return response.status
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
adding error checking for the hooks helper functions and and try/catch clause to API helper to make them less prone to errors or at least easier to understand why something is failing if there is an error with deleting files. 

## Related Issue
- relates to https://github.com/owncloud/web-app-dicom-viewer/issues/48

## Motivation and Context
make app less prone to errors and improve debugging

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added/enhanced