### PR TITLE
remove purple border around dicom image preview

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -562,7 +562,8 @@ export default defineComponent({
     },
     setViewportCameraParallelScaleFactor() {
       const camera = this.viewport.getCamera()
-      this.viewportCameraParallelScale = camera.parallelScale * 0.925 // add small correction factor to remove purple border around image
+      this.viewportCameraParallelScale = camera.parallelScale * 0.925
+      // add small correction factor to remove purple border around image
     },
     // functions for styling data
     formatOverlayDateAndTime(date: string, time: string) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -260,9 +260,7 @@ export default defineComponent({
 
       // set initial parallel scale factor and render the image (updates every viewport in the rendering engine)
       this.setViewportCameraParallelScaleFactor()
-      // this.setZoom(this.currentImageZoom)
-      // TODO: figure out how to refresh viewport (display image with modified parallel scale factor)
-
+      this.setZoom(this.currentImageZoom)
       this.viewport.render()
 
       // getting image metadata from viewport

--- a/src/App.vue
+++ b/src/App.vue
@@ -260,7 +260,9 @@ export default defineComponent({
 
       // set initial parallel scale factor and render the image (updates every viewport in the rendering engine)
       this.setViewportCameraParallelScaleFactor()
-      this.setZoom(this.currentImageZoom)
+      // this.setZoom(this.currentImageZoom)
+      // TODO: figure out how to refresh viewport (display image with modified parallel scale factor)
+
       this.viewport.render()
 
       // getting image metadata from viewport

--- a/src/App.vue
+++ b/src/App.vue
@@ -258,9 +258,10 @@ export default defineComponent({
       // set stack on the viewport (currently only one image in the stack, therefore no frame # required)
       await this.viewport.setStack(dicomStack)
 
-      // render the image (updates every viewport in the rendering engine)
-      this.viewport.render()
+      // set initial parallel scale factor and render the image (updates every viewport in the rendering engine)
       this.setViewportCameraParallelScaleFactor()
+      this.setZoom(this.currentImageZoom)
+      this.viewport.render()
 
       // getting image metadata from viewport
       this.getImageMetadataFromViewport(this.dicomUrl)
@@ -268,8 +269,6 @@ export default defineComponent({
   },
   updated() {
     // this.viewport.resize()
-    // also check if it is needed to recalculate scale factor
-    // this.setViewportCameraParallelScaleFactor()
   },
   beforeUnmount() {
     this.renderingEngine.destroy()
@@ -563,7 +562,7 @@ export default defineComponent({
     },
     setViewportCameraParallelScaleFactor() {
       const camera = this.viewport.getCamera()
-      this.viewportCameraParallelScale = camera.parallelScale
+      this.viewportCameraParallelScale = camera.parallelScale * 0.925 // add small correction factor to remove purple border around image
     },
     // functions for styling data
     formatOverlayDateAndTime(date: string, time: string) {

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -19,8 +19,9 @@ vi.mock('@cornerstonejs/core', () => {
         return {
           setStack: vi.fn(),
           render: vi.fn(),
+          setCamera: vi.fn(),
           getCamera: vi.fn().mockImplementation(() => {
-            return { parallelScale: 137.3853139193763 }
+            return { parallelScale: 127.08141537542309 }
           }),
           getImageData: vi.fn().mockImplementation(() => {
             return { dimensions: [] }


### PR DESCRIPTION
## Description
reduce purple border around dicom image preview to thin line

## Related Issue
- Fixes https://github.com/owncloud/web-app-dicom-viewer/issues/55

## Motivation and Context
nicer user experience

## Screenshots (if appropriate):
width of purple area around preview in initial size (at 100%) has been reduced to a very thin line:

![Screen Shot 2024-08-15 at 11 30 09](https://github.com/user-attachments/assets/0c311dd3-420b-4f65-85dd-7b67a7cdfb79)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added