### PR TITLE
update icon for flipping image

### DIFF
--- a/src/components/DicomControls.vue
+++ b/src/components/DicomControls.vue
@@ -96,8 +96,7 @@
           :aria-label="imageFlipHorizontalDescription"
           @click="$emit('setHorizontalFlip')"
         >
-          <oc-icon fill-type="line" name="arrow-left-right" variation="inherit" />
-          <!-- "arrow-left-right" is used as placeholder until "flip-horizontal" is included in web's design-system -->
+          <oc-icon fill-type="line" name="flip-horizontal-2" variation="inherit" />
         </oc-button>
         <oc-button
           v-oc-tooltip="imageFlipVerticalDescription"
@@ -107,8 +106,7 @@
           :aria-label="imageFlipVerticalDescription"
           @click="$emit('setVerticalFlip')"
         >
-          <oc-icon fill-type="line" name="arrow-up-down" variation="inherit" />
-          <!-- "arrow-left-right" is used as placeholder until "flip-vertical" is included in web's design-system -->
+          <oc-icon fill-type="line" name="flip-vertical-2" variation="inherit" />
         </oc-button>
       </div>
       <div class="oc-flex oc-flex-middle">


### PR DESCRIPTION
## Description
In the [scribbles for the dicom viewer app](https://whimsical.com/dicom-viewer-GLceztrP2ESxrKK6TTrJ4A) we had been using an icon for the flip image functionality that was not part of the remix icon set (the icon set didn't offer any icon for this purpose at that time). In the meanwhile the publishers of the remix icon set have added such an icon as suggested by us. In fact, they have even provided 2 variants (see https://github.com/Remix-Design/RemixIcon/issues/650#issuecomment-1965626094). In this PR we have updated the icon to the one that was initially used in the scribbles. 

## Related Issue
- relates to https://github.com/owncloud/web/pull/10172 and https://github.com/owncloud/web-app-dicom-viewer/issues/2

## Motivation and Context
make UI more intuitive by using suitable, less ambiguous icons

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added