### PR TITLE
Add missing mock function

### DIFF
--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -19,6 +19,7 @@ vi.mock('@cornerstonejs/core', () => {
         return {
           setStack: vi.fn(),
           render: vi.fn(),
+          setCamera: vi.fn(),
           getCamera: vi.fn().mockImplementation(() => {
             return { parallelScale: 137.3853139193763 }
           }),


### PR DESCRIPTION
## Description
This pr adds mock for `setCamera`.

## Related Issue

## Motivation and Context
Unit test failed because of missing `setCamera` mock function in https://github.com/owncloud/web-app-dicom-viewer/pull/56.
```
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
TypeError: this.viewport.setCamera is not a function
 ❯ Proxy.setZoom src/App.vue:630:21
    628|       }
    629| 
    630|       this.viewport.setCamera(newCamera)
       |                     ^
    631|       this.viewport.render()
    632|     },
 ❯ Proxy.mounted src/App.vue:263:12

This error originated in "tests/unit/App.spec.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
The latest test that might've caused the error is "should fetch overlay metadata when the url is provided". It might mean one of the following:
- The error was thrown, while Vitest was running this test.
- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added