### PR TITLE
added docker file for creating docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM node:alpine AS stage
+FROM owncloudci/nodejs:20 AS stage
 
 WORKDIR /extension
 
 COPY . .
-RUN npm install -g pnpm
 RUN pnpm install
 RUN pnpm build
 
-FROM node:alpine
+FROM alpine:3.20
 WORKDIR /app
 COPY --from=stage /extension/dist ./ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:alpine AS stage
+
+WORKDIR /extension
+
+COPY . .
+RUN npm install -g pnpm
+RUN pnpm install
+RUN pnpm build
+
+FROM node:alpine
+WORKDIR /app
+COPY --from=stage /extension/dist ./ 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-IMAGE_NAME = owncloud/web-app-dicom-viewer/dicom-viewer
-TAG = 1.0.0
-
-.PHONY: docker-build
-docker-build:
-	docker build -t $(IMAGE_NAME):$(TAG) .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+IMAGE_NAME = owncloud/web-app-dicom-viewer/dicom-viewer
+TAG = 1.0.0
+
+.PHONY: docker-build
+docker-build:
+	docker build -t $(IMAGE_NAME):$(TAG) .

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,5 +12,12 @@ export default defineConfig({
       key: readFileSync(join(certsDir, 'server.key')),
       cert: readFileSync(join(certsDir, 'server.crt'))
     }
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'js/web-app-dicom-viewer.js'
+      }
+    }
   }
 })


### PR DESCRIPTION
## Description
This PR add dockerfile that can be used to create docker image.

Vite config for build is updated so that the build version inside dist that is created will have same path as defined in `manifest.json` inside public folder which will be copied inside the dist and later used to create docker image.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to https://github.com/owncloud/web-app-dicom-viewer/issues/64 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
<!--- Put screenshots or images related to this issue -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)

## Checklist:
<!--- Put an `x` in all the boxes that apply for this PR: -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added