### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,175 +1,171 @@
 # ownCloud Web DICOM Viewer
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/web-app-dicom-viewer/status.svg)](https://drone.owncloud.com/owncloud/web-app-dicom-viewer)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_web-app-dicom-viewer&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=owncloud_web-app-dicom-viewer)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_web-app-dicom-viewer&metric=coverage)](https://sonarcloud.io/summary/new_code?id=owncloud_web-app-dicom-viewer)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-The ownCloud Web DICOM Viewer app is an extension of [ownCloud Web](https://github.com/owncloud/web) to preview DICOM files (medical images and their corresponding metadata) in the browser. The preview of the medical images is based on MIT licensed [cornerstone3D](https://github.com/cornerstonejs/cornerstone3D).
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/web-app-dicom-viewer)
 
+The ownCloud Web DICOM Viewer is an extension for ownCloud Web that enables previewing DICOM files (medical images and their corresponding metadata) directly in the browser. Built on the MIT-licensed cornerstone3D library, it provides image manipulation tools including zoom, rotation, flipping and color inversion, along with responsive metadata display adapted to the user's screen size.
 
-## Table of Contents
+## Part of oCIS
 
-* [Functionalities of DICOM Viewer Web Extension](#functionalities-of-dicom-viewer-web-extension)
-* [Adding DICOM Viewer to Your oCIS Installation](#adding-dicom-viewer-to-your-ocis-installation)
-  * [Adding DICOM Viewer to the oCIS Deployment Example](#adding-dicom-viewer-to-the-ocis-deployment-example)
-  * [Manual App Installation](#manual-app-installation)
-* [Build and Run DICOM Viewer for Development](#build-and-run-dicom-viewer-for-development)
-* [Contributing to DICOM Viewer Web Extension](#contributing-to-dicom-viewer-web-extension)
-* [Copyright](#copyright)
+This extension is part of the [ownCloud Infinite Scale (oCIS)](https://github.com/owncloud/ocis) ecosystem, extending the [ownCloud Web](https://github.com/owncloud/web) frontend with medical imaging capabilities. It requires oCIS >= 6.2.x and Web >= 9.x.x.
 
+The DICOM Viewer is available on [Docker Hub](https://hub.docker.com/r/owncloud/web-app-dicom-viewer).
 
-## Functionalities of DICOM Viewer Web Extension
+## Getting Started
 
-The current release allows previewing .dcm files within oCIS and displaying their corresponding metadata in a sidebar on request. It offers image manipulation operations such as zoom in and out, rotation, flipping, colour inversion and reset on the image preview. The app UI is implemented in a responsive manner and adapts the size of the image preview and the way that metadata is displayed to the screen size of the device.
+Follow the steps below to install the DICOM Viewer extension.
 
-<img src="https://github.com/owncloud/awesome-ocis/blob/main/webApps/owncloud/web-app-dicom-viewer/screenshots/1.png" alt="app functionalities" style="width:48%; height:auto;"> &nbsp; &nbsp; <img src="https://github.com/owncloud/awesome-ocis/blob/main/webApps/owncloud/web-app-dicom-viewer/screenshots/4.png" alt="display of metadata" style="width:48%; height:auto;">
+### Quick Installation
 
-_The extension allows previewing a DICOM image and it's most important metadata. On request, all corresponding metadata of the file are displayed in the sidebar._
+1. Download the zip from the [releases page](https://github.com/owncloud/web-app-dicom-viewer/releases)
+2. Extract to the `apps` directory of your oCIS server (set via `WEB_ASSET_APPS_PATH`)
 
-<img src="https://github.com/owncloud/awesome-ocis/blob/main/webApps/owncloud/web-app-dicom-viewer/screenshots/2.png" alt="app functionalities" style="width:48%; height:auto;"> &nbsp; &nbsp; <img src="https://github.com/owncloud/awesome-ocis/blob/main/webApps/owncloud/web-app-dicom-viewer/screenshots/3.png" alt="display of metadata" style="width:48%; height:auto;">
+### Docker Compose (oCIS Deployment Example)
 
-_The extension allows the user to zoom, rotate and flip the preview of the image. Inverting the colors of the preview is also supported._
+1. Copy `dicom-viewer.yml` into the `web_extensions` subfolder
+2. Add `DICOMVIEWER=:web_extensions/dicom-viewer.yml` to the `.env` file
+3. Append `${DICOMVIEWER:-}` to the `COMPOSE_FILE` variable
+4. Update `csp.yaml` with the DICOM Viewer app ID
 
+See the [full deployment instructions](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-prod.html).
 
-## Adding DICOM Viewer to Your oCIS Installation
-As oCIS administrator, you can add custom web applications for your users. By adding the DICOM Viewer to the oCIS WebUI, you enable your users to take advantage of the [functionalities of this web extension](#functionalities-of-dicom-viewer-web-extension).
+### Development Setup
 
-
-### Adding DICOM Viewer to the oCIS Deployment Example
-oCIS provides some [deployment examples](https://github.com/owncloud/ocis/tree/master/deployments/examples/) including detailed configuration step by step guides for [local production setup](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-prod.html) and [deployment of Infinite Scale on the Hetzner Cloud](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-hetzner.html).
-In both cases, it only takes a few very small and simple steps to add the DICOM Viewer Web Extension to the [`ocis_full` deployment example](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_full/) of your own installation:
-
-1. Navigate to the `/opt/compose/ocis/ocis_full` folder of your installation and copy [`dicom-viewer.yml`](https://github.com/owncloud/web-app-dicom-viewer/blob/main/dicom-viewer.yml) into the [`web_extensions`](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_full/web_extensions) subfolder.
-
-2. Add `DICOMVIEWER=:web_extensions/dicom-viewer.yml` to the `## oCIS Web Extensions ##` section of the `.env` file of your installation (file is located in `/opt/compose/ocis/ocis_full`).\
-Your `.env` file should now look like this:
-   ```
-   ## oCIS Web Extensions ##
-   # It is possible to use the oCIS Web Extensions to add custom functionality to the oCIS frontend.
-   # For more details see https://github.com/owncloud/web-extensions/blob/main/README.md
-   
-   <list of all web extensions>
-   
-   DICOMVIEWER=:web_extensions/dicom-viewer.yml
-   ```
-
-3. Append `${DICOMVIEWER:-}` to the `COMPOSE_FILE` variable at the very end of the last line of the `.env` file. This variable combines the configs of all the components that need to be loaded.
-
-   `COMPOSE_FILE=docker-compose.yml${OCIS:-} ... <variables of lots of other configs that are added to docker compose> ... ${DICOMVIEWER:-}`
-
-   After appending `${DICOMVIEWER:-}`, your `.env` file should look like this:
-   ```
-   ## IMPORTANT ##
-   # This MUST be the last line as it assembles the supplemental compose files to be used.
-   # ALL supplemental configs must be added here, whether commented or not.
-   # Each var must either be empty or contain :path/file.yml
-   COMPOSE_FILE=docker-compose.yml${OCIS:-}${TIKA:-}${S3NG:-}${S3NG_MINIO:-}${COLLABORA:-}${MONITORING:-}${IMPORTER:-}${CLAMAV:-}${ONLYOFFICE:-}${INBUCKET:-}${EXTENSIONS:-}${UNZIP:-}${DRAWIO:-}${JSONVIEWER:-}${PROGRESSBARS:-}${EXTERNALSITES:-}${DICOMVIEWER:-}
-   ```
-
-4. Update the `csp.yaml` file located in `/config/ocis/csp.yaml` by adding the 
-`"id": "com.github.owncloud.web-app-dicom-viewer"` block as shown in the [webApps/apps.json](https://github.com/owncloud/awesome-ocis/blob/main/webApps/apps.json) example.
-
-Done! Have fun using the [functionalities of the DICOM Viewer web extension](#functionalities-of-dicom-viewer-web-extension) on your installation!
-
-
-### Manual App Installation
-
-1. Download the zip file from the [releases page](https://github.com/owncloud/web-app-dicom-viewer/releases).
-2. Extract the zip file to the `apps` directory of your oCIS server. The `apps` directory is set using the `WEB_ASSET_APPS_PATH` environment variable.
-
-#### Prerequisites
-
-- Supported oCIS and Web Versions: oCIS (>= 6.2.x), Web (>= 9.x.x)
-- Supported Architectures: `amd64`
-
-#### Additional Information
-
-Have a look at the ownCloud Infinite Scale Deployment documentation to learn how to [extend the WebUI with apps](https://doc.owncloud.com/ocis/next/deployment/webui/webui-customisation.html#extend-web-ui-with-apps). You will find instructions how to [load custom applications](https://doc.owncloud.com/ocis/next/deployment/webui/webui-customisation.html#loading-applications) into your installation and get a better understanding of the web extension [application structure](https://doc.owncloud.com/ocis/next/deployment/webui/webui-customisation.html#application-structure) and [application configuration](https://doc.owncloud.com/ocis/next/deployment/webui/webui-customisation.html#application-configuration).
-
-
-## Build and Run DICOM Viewer for Development
-
-### Prerequisites
-
-- [Node.js `v18`](https://nodejs.org/en/)
-- [pnpm `v8`](https://pnpm.io/)
-- [Docker Compose](https://docs.docker.com/compose/)
-
-
-### 1. Install Dependencies
+Prerequisites: Node.js v18, pnpm v8, Docker Compose
 
 ```bash
-pnpm install
+pnpm install               # Install dependencies
+docker compose up           # Start oCIS server
+pnpm build:w               # Build with watch mode
 ```
 
-### 2. Run oCIS Server
+Access the Web UI at [localhost:9200](https://localhost:9200).
+
+### Running Tests
 
 ```bash
-docker compose up
+pnpm test                  # Run unit tests (Vitest)
+pnpm coverage              # Run tests with coverage
+pnpm lint                  # Run ESLint
+pnpm test:e2e              # Run e2e tests (Cucumber)
 ```
 
-### 3. Build the Extension
+## Documentation
 
-Build the extension using watch for development.
+- [Extend Web UI with Apps](https://doc.owncloud.com/ocis/next/deployment/webui/webui-customisation.html#extend-web-ui-with-apps)
+- [Loading Applications](https://doc.owncloud.com/ocis/next/deployment/webui/webui-customisation.html#loading-applications)
+- [ownCloud Web Extension System](https://owncloud.dev/clients/web/extension-system/)
 
-```bash
-pnpm build:w
-```
+## Features
 
-### 4. Load the Extension
+Capabilities of the DICOM medical image viewer:
 
-We can load the app into the oCIS server in two different ways, depending on the version of oCIS:
+### Image Viewing
 
-#### For oCIS 5.0.0 (Separate Extension Server)
+- Preview `.dcm` (DICOM) files directly in the oCIS web interface
+- Zoom in/out, rotation, flipping, and color inversion controls
+- Fullscreen mode with reset capability
+- Responsive layout that adapts image preview and metadata display to screen size
 
-Configure the extension in `web.config.json`
+### Metadata Display
 
-```json
-{
-  …
-  "external_apps": [
-    {
-      "id": "dicom-viewer",
-      "path": "https://host.docker.internal:9999/js/web-app-dicom-viewer.js",
-      "config": {
-        "mimeTypes": [
-          "application/dicom",
-          "application/octet-stream",
-          "application/dicom+xml",
-          "application/json"
-        ]
-      }
-    }
-  ]
-}
+- Key DICOM metadata shown alongside the image preview
+- Full metadata available in a collapsible sidebar on request
 
-```
+### Deployment via Docker Compose
 
-#### For oCIS >= 5.1
+For `ocis_full` deployment examples:
 
-Copy `docker-compose.override.example.yml` to `docker-compose.override.yml`.
+1. Copy `dicom-viewer.yml` into `web_extensions/`
+2. Add `DICOMVIEWER=:web_extensions/dicom-viewer.yml` to the `.env` file under `## oCIS Web Extensions ##`
+3. Append `${DICOMVIEWER:-}` to the `COMPOSE_FILE` variable
+4. Update `csp.yaml` with the app ID `com.github.owncloud.web-app-dicom-viewer`
 
+### Supported Versions
 
-### 5. Have Fun
+- oCIS >= 6.2.x
+- Web >= 9.x.x
+- Architecture: `amd64`
 
-You can access oCIS WebUI with the DICOM Viewer extension through [localhost:9200](https://localhost:9200).
+### Docker Image
 
+Available as `registry.owncloud.com/internal/web-app-dicom-viewer:latest` (exposed port: `8080`).
 
-### Docker Tags and Respective Dockerfile Links
+## Community & Support
 
-- [`latest`](https://github.com/owncloud/web-app-dicom-viewer/blob/master/docker/Dockerfile) available as `registry.owncloud.com/internal/web-app-dicom-viewer:latest`
-- Default volumes: None
-- Exposed ports: `8080`
-- Environment variables: None
+**[Star](https://github.com/owncloud/web-app-dicom-viewer)** this repo and **Watch** for release notifications!
 
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
 
-## Contributing to DICOM Viewer Web Extension
+## Contributing
 
-Contribution in the form of bug reports, user feedback or actual code is always welcome! Please file issues [here](https://github.com/owncloud/web-app-dicom-viewer/issues).
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
 
+### Workflow
 
-## Copyright
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
 
-```Text
-Copyright (c) 2023 ownCloud GmbH
-```
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud-web/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [AGPL-3.0](LICENSE).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: AGPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All AGPL/GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: AGPL-3.0 is a strong copyleft license; migration requires full relicensing of all files, not just a header change

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,83 @@
+# agents.md — web-app-dicom-viewer
+
+## Repository Overview
+
+An ownCloud Web extension for previewing DICOM medical images and metadata in the browser. Built on cornerstone3D, it provides image manipulation tools (zoom, rotate, flip, invert) and responsive metadata display.
+
+- **Classification:** oCIS
+- **Activity Status:** Active
+- **License:** AGPL-3.0
+- **Language:** TypeScript, Vue.js
+
+## Architecture & Key Paths
+
+- `src/` — Extension source code (Vue components, TypeScript logic)
+- `public/` — Static assets
+- `tests/` — Unit tests (Vitest) and e2e tests (Cucumber/Playwright)
+- `docker/` — Docker configuration
+- `dev/` — Development environment configuration
+- `l10n/` — Localization files
+- `Dockerfile` — Container image for the extension
+- `package.json` — Dependencies and scripts
+- `vite.config.ts` — Vite build configuration
+- `vitest.config.ts` — Vitest test configuration
+- `docker-compose.yml` — Development environment with oCIS
+- `dicom-viewer.yml` — Deployment config for oCIS deployment examples
+- `extension.d.ts` — TypeScript type definitions
+
+## Development Conventions
+
+- TypeScript/Vue.js with Vite build tooling
+- Prettier for code formatting
+- Issue and PR templates available
+- Docker Compose for local development
+- SonarCloud for quality analysis
+
+## Build & Test Commands
+
+```bash
+pnpm install                # Install dependencies
+pnpm build                  # Production build
+pnpm build:w                # Build with watch (development)
+pnpm build:prod             # Production build with PRODUCTION flag
+pnpm test                   # Run unit tests (Vitest)
+pnpm coverage               # Run tests with coverage report
+pnpm lint                   # Run ESLint
+pnpm test:e2e               # Run e2e tests (Cucumber)
+docker compose up           # Start development oCIS server
+```
+
+## Important Constraints
+
+- **AGPL-3.0 copyleft license:** The OSPO Apache 2.0 migration requires auditing this copyleft license.
+- **cornerstone3D dependency:** Image rendering uses the MIT-licensed cornerstone3D library.
+- **oCIS version requirements:** Requires oCIS >= 6.2.x and Web >= 9.x.x.
+- **Architecture support:** Docker images only support `amd64`.
+- **Docker image:** Published as `registry.owncloud.com/internal/web-app-dicom-viewer`.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+- This is an oCIS Web extension, not an OC10 app.
+- The `src/` directory contains Vue components for DICOM rendering and metadata display.
+- The `dicom-viewer.yml` file is the deployment configuration for oCIS deployment examples.
+- Development requires Docker Compose for the oCIS backend.
+- The extension registers as a file handler for `.dcm` files and related MIME types.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>